### PR TITLE
Move from distutils to setuptools.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
-from distutils.core import setup
+from setuptools import setup
+
 with open('README.md') as f:
     long_description = f.read()
+
 setup(
   name = 'py-data-structure',         # How you named your package folder (MyLib)
   packages = ['py-data-structure'],   # Chose the same as "name"


### PR DESCRIPTION
Distutils is deprecated. Setuptools should be used instead.

Link to PEP for deprecation: https://www.python.org/dev/peps/pep-0632