### PR TITLE
Added Support for unordered_map C++ Data Structure to Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,32 @@ Get the whole queue in a list format:
 ```python
 print(queue.get_queue())
 ```
+
+## Unordered Maps:
+```python
+from py_data_structure import Unordered_map
+```
+
+Create an unordered map:
+```python
+unordered_map = Unordered_map()
+```
+
+Add a value to the unordered map:
+```python
+unordered_map.push_back(value)
+```
+
+Get a value from the unordered map:
+```python
+unordered_map.get_value(index)
+```
+
+Get an element(sublist value) from the unordered map:
+```python
+unordered_map.get_element(index1,index2)
+```
+
 ## Reporting a Vulnerability
 
 Do you have any suggestions, questions, comments, or concerns? Reach out to the developer at vihan.raval1@gmail.com or at GitHub to report an issue!

--- a/py_data_structure/__init__.py
+++ b/py_data_structure/__init__.py
@@ -1,1 +1,1 @@
-from py_data_structure.main import Stack,Queue
+from py_data_structure.main import Stack,Queue,unordered_map

--- a/py_data_structure/__init__.py
+++ b/py_data_structure/__init__.py
@@ -1,1 +1,1 @@
-from py_data_structure.main import Stack,Queue,unordered_map
+from py_data_structure.main import Stack,Queue,Unordered_map

--- a/py_data_structure/main.py
+++ b/py_data_structure/main.py
@@ -34,3 +34,14 @@ class Queue:
             return False
     def size(self): return len(self.queue)
     def get_queue(self): return self.queue
+class unordered_map:
+    def __init__(self):
+        self.uMap = {}
+        self.key = 0
+    def push_back(self,value):
+        self.uMap[key] = value
+        self.key+=1
+    def get_value(self,index):
+        return self.uMap[index]
+    def get_element(self,index1,index2):
+        return self.uMap[index1][index2]

--- a/py_data_structure/main.py
+++ b/py_data_structure/main.py
@@ -34,7 +34,7 @@ class Queue:
             return False
     def size(self): return len(self.queue)
     def get_queue(self): return self.queue
-class unordered_map:
+class Unordered_map:
     def __init__(self):
         self.uMap = {}
         self.key = 0


### PR DESCRIPTION
Hello,

I have made changes to add a significant C++ data structure to Python: the unordered_map. The unordered map is much more useful than a normal dictionary/map because it completes operations in O(1) time. I have added support to incorporate this data structure in Python.

Key Changes:

- Added Unordered_map data structure and other operations like push_back
- Changed __init__.py to make the data structure usable
- Added Documentation for the unordered_map functions